### PR TITLE
Update `Gemfile.lock` to match gem version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    raix-rails (0.3.0)
+    raix-rails (0.3.1)
       activesupport (>= 6.0)
       open_router (~> 0.2)
 
@@ -196,7 +196,7 @@ GEM
       yard (>= 0.9)
 
 PLATFORMS
-  arm64-darwin-21
+  arm64-darwin
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
Running `bundle install` was showing that `Gemfile.lock` was out-of-sync with the gem version.

I also removed the version suffix for `arm64-darwin` so that it doesn't become stale every time there's new macOS version.