### PR TITLE
Update default model

### DIFF
--- a/lib/raix.rb
+++ b/lib/raix.rb
@@ -27,7 +27,7 @@ module Raix
     attr_accessor :openai_client
 
     DEFAULT_MAX_TOKENS = 1000
-    DEFAULT_MODEL = "meta-llama/llama-3-8b-instruct:free"
+    DEFAULT_MODEL = "meta-llama/llama-3.3-8b-instruct:free"
     DEFAULT_TEMPERATURE = 0.0
 
     # Initializes a new instance of the Configuration class with default values.

--- a/spec/raix/chat_completion_spec.rb
+++ b/spec/raix/chat_completion_spec.rb
@@ -4,7 +4,7 @@ class MeaningOfLife
   include Raix::ChatCompletion
 
   def initialize
-    self.model = "meta-llama/llama-3-8b-instruct:free"
+    self.model = "meta-llama/llama-3.3-8b-instruct:free"
     self.seed = 9999 # try to get reproduceable results
     transcript << { user: "What is the meaning of life?" }
   end


### PR DESCRIPTION
The current model is no longer available on OpenRouter, this looks to be the closest:

https://openrouter.ai/meta-llama/llama-3.3-8b-instruct:free