### PR TITLE
Make ruby-openai dependency explicit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,6 @@ gemspec
 gem "activesupport", ">= 6.0"
 gem "faraday-retry"
 gem "open_router", "~> 0.3"
-gem "ruby-openai", "~> 7.0"
 
 group :development do
   gem "dotenv", ">= 2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,10 @@
 PATH
   remote: .
   specs:
-    raix-rails (0.3.0)
+    raix-rails (0.3.1)
       activesupport (>= 6.0)
       open_router (~> 0.2)
+      ruby-openai (~> 7.0)
 
 GEM
   remote: https://rubygems.org/
@@ -197,6 +198,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  arm64-darwin-24
   x86_64-linux
 
 DEPENDENCIES
@@ -211,7 +213,6 @@ DEPENDENCIES
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.21)
-  ruby-openai (~> 7.0)
   solargraph-rails (~> 0.2.0.pre)
   sorbet
   tapioca

--- a/raix-rails.gemspec
+++ b/raix-rails.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "activesupport", ">= 6.0"
   spec.add_dependency "open_router", "~> 0.2"
+  spec.add_dependency "ruby-openai", "~> 7.0"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
`lib/raix/chat_completion.rb` has a `require` for `openai`.

https://github.com/OlympiaAI/raix-rails/pull/4 should be merged first.