### PR TITLE
Update GitHub Actions checkout action to v4 to fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           - '3.2.2'
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
This should prevent the failure seen in https://github.com/OlympiaAI/raix-rails/actions/runs/9258011866/job/25467299809